### PR TITLE
Fixed a waay to evade softban using rejoin

### DIFF
--- a/bumputils/__init__.py
+++ b/bumputils/__init__.py
@@ -1,0 +1,4 @@
+from .bumputils import BumpUtils
+
+async def setup(bot):
+    await bot.add_cog(BumpUtils(bot))

--- a/bumputils/bumputils.py
+++ b/bumputils/bumputils.py
@@ -1,0 +1,17 @@
+import discord
+
+from redbot.core import commands, app_commands, Config
+
+class BumpUtils(commands.Cog):
+    
+    def __init__(self, bot):
+        self.bot = bot
+        self.config = Config.get_conf(self, identifier=518963742)
+        self.config.register_guild(
+            command="",
+            channel=0,
+            user={}
+        )
+
+
+    bumputils = app_commands.Group(name="bumputils", description="Zähle wie oft eine Person einen Command genutzt hat")

--- a/bumputils/info.json
+++ b/bumputils/info.json
@@ -1,0 +1,17 @@
+{
+    "author": [
+        "Nia"
+    ],
+    "install_msg": "Commandcount wurde erfolgreich installiert",
+    "name": "Modsystem",
+    "short": "Mit diesem Cog ist es möglich zu zählen wie oft ein User einen Command benutzt hat",
+    "description": "Es wird geloggt wie oft ein User einen Command benutzt hat und welchen Rang er hat",
+    "tags": [
+        "count",
+        "leaderboard",
+        "log"
+    ],
+    "requirements": [
+        "pillow"
+    ]
+}

--- a/modsystem/modsystem.py
+++ b/modsystem/modsystem.py
@@ -516,8 +516,8 @@ class Modsystem(commands.Cog):
                 embed.description += (f"Modrolle: {interaction.guild.get_role(await self.config.guild(interaction.guild).modRole()).mention}\n")
             else:
                 embed.description += (f"Modrolle: **Keine gültige Rolle gesetzt**\n")
-            embed.description += (f"Link detection pattern: **{await self.config.guild(interaction.guild).linkPattern()}**\n")
-            await interaction.response.send_message(embed=embed)
+            embed.description += (f"Link detection pattern: `{await self.config.guild(interaction.guild).linkPattern()}`")
+            await interaction.response.send_message(embed=embed, ephemeral=True)
         except Exception as error:
             embedFailure.description=f"**Es ist folgender Fehler aufgetreten:**\n\n{error}"
             await interaction.response.send_message(embed=embedFailure, ephemeral=True)
@@ -642,7 +642,6 @@ class Modsystem(commands.Cog):
                         timeou_until = datetime.now().astimezone() + timedelta(minutes=timeout)
                         await user.timeout(timeou_until, reason=reason)
                 case "kick":
-                    await user.kick(reason=reason)
                     embedResponse.description=(f"{user.mention} wurde mit der Begründung **{reason}** gekickt\n\n"
                                                f"Aktuelle Punkte: **{await self.config.guild(interaction.guild).users.get_raw(user.id, 'currentPoints')}**\n"
                                                f"Kickgrenze: **{await self.config.guild(interaction.guild).warnKickWeight()}**\n"
@@ -659,8 +658,8 @@ class Modsystem(commands.Cog):
                                          f"Punkte: **{await self.config.guild(interaction.guild).users.get_raw(user.id, 'currentPoints')}**\n"
                                          f"Dies ist dein **{await self.config.guild(interaction.guild).users.get_raw(user.id, 'kickCount')}.** Kick\n"
                                          f"Verbleibende Punkte bis zum Ban: **{await self.config.guild(interaction.guild).warnBanWeight() - await self.config.guild(interaction.guild).users.get_raw(user.id, 'currentPoints')}**\n")
+                    await user.kick(reason=reason)
                 case "ban":
-                    await user.ban(reason=reason, delete_message_days=1)
                     embedResponse.description=(f"{user.mention} wurde mit der Begründung **{reason}** gebannt\n\n"
                                                f"Aktuelle Punkte: **{await self.config.guild(interaction.guild).users.get_raw(user.id, 'currentPoints')}**\n"
                                                f"Anzahl der Kicks: **{await self.config.guild(interaction.guild).users.get_raw(user.id, 'kickCount')}**\n"
@@ -671,7 +670,7 @@ class Modsystem(commands.Cog):
                                              f"### Begrpndung\n"
                                              f"**{reason}**")
                     embedDM.description=(f"Du wurdest gerade von {interaction.user.display_name} mit der Begründung **{reason}** gebant\n\n")
-                        
+                    await user.ban(reason=reason, delete_message_days=1)
             if(sendPChannel):
                 await interaction.guild.get_channel(int(await self.config.guild(interaction.guild).warnPublicChannel())).send(embed=embedPublic)
 
@@ -722,6 +721,7 @@ class Modsystem(commands.Cog):
                 if(dict(await self.config.guild(interaction.guild).users()).get(str(interaction.user.id)) is not None):
                     currentUserRecord = await self.config.guild(interaction.guild).users.get_raw(interaction.user.id)
                     ban = "Ja" if currentUserRecord.get("banned") == True else "Nein"
+                    softbann = "Ja" if currentUserRecord.get("softBanned") == True else "Nein"
                     embed.description=(f"**Es ist aktuell folgendes von {interaction.user.mention} gespeichert:**\n\n"
                                        f"Begründung des letzten Warns: **{currentUserRecord.get('currentReason')}**\n"
                                        f"Aktuelle Punkte: **{currentUserRecord.get('currentPoints')}**\n"
@@ -729,6 +729,7 @@ class Modsystem(commands.Cog):
                                        f"Erster Warn am **{currentUserRecord.get('firstWarn')}** erhalten\n"
                                        f"Letzter Warn am **{currentUserRecord.get('lastWarn')}** erhalten\n"
                                        f"Anzahl an Kicks durch Warns: **{currentUserRecord.get('kickCount')}**\n"
+                                       f"Softbann: **{softbann}**\n"
                                        f"User gebannt: **{ban}**")
                     embed.set_thumbnail(url=interaction.user.display_avatar.url)
                 else:
@@ -738,6 +739,7 @@ class Modsystem(commands.Cog):
                 if(dict(await self.config.guild(interaction.guild).users()).get(str(user.id)) is not None):
                     currentUserRecord = await self.config.guild(interaction.guild).users.get_raw(user.id)
                     ban = "Ja" if currentUserRecord.get("banned") == True else "Nein"
+                    softbann = "Ja" if currentUserRecord.get("softBanned") == True else "Nein"
                     embed.description=(f"**Es ist aktuell folgendes von {user.mention} gespeichert:**\n\n"
                                     f"Begründung des letzten Warns: **{currentUserRecord.get('currentReason')}**\n"
                                     f"Aktuelle Punkte: **{currentUserRecord.get('currentPoints')}**\n"
@@ -745,6 +747,7 @@ class Modsystem(commands.Cog):
                                     f"Erster Warn am **{currentUserRecord.get('firstWarn')}** erhalten\n"
                                     f"Letzter Warn am **{currentUserRecord.get('lastWarn')}** erhalten\n"
                                     f"Anzahl an Kicks durch Warns: **{currentUserRecord.get('kickCount')}**\n"
+                                    f"Softbann: **{softbann}**\n"
                                     f"User gebannt: **{ban}**")
                     embed.set_thumbnail(url=user.display_avatar.url)
                 else:
@@ -817,16 +820,7 @@ class Modsystem(commands.Cog):
                 raise Exception("Kein gültiger Channel gesetzt")
             elif(await self.config.guild(interaction.guild).users.get_raw(user.id, 'softBanned')):
                 raise Exception("Dieser User ist bereits im Softban")
-            sbChannel = await self.config.guild(interaction.guild).softBanChannel()
-            overwriteHide = discord.PermissionOverwrite()
-            overwriteShow = discord.PermissionOverwrite()
-            overwriteHide.view_channel=False
-            overwriteShow.view_channel=True
-            for channel in interaction.guild.channels:
-                if(channel.id == sbChannel):
-                    await channel.set_permissions(user, overwrite=overwriteShow)
-                else:
-                    await channel.set_permissions(user, overwrite=overwriteHide)
+            await Modsystem.do_softban(user, interaction.guild.channels, await self.config.guild(interaction.guild).softBanChannel())
             await self.config.guild(interaction.guild).users.set_raw(user.id, 'softBanned', value=True)
             await user.send(f"Du hast einen Softban auf **{interaction.guild.name}** bekommen")
             embedLog.description=f"{user.mention} hat von {interaction.user.mention} einen **Softban** bekommen"
@@ -840,6 +834,21 @@ class Modsystem(commands.Cog):
             embedFailure.description=f"**Es ist folgender Fehler aufgetreten:**\n\n{error}"
             await interaction.followup.send(embed=embedFailure, ephemeral=True)
 
+    async def do_softban(user: discord.user, channels: discord.Guild.channels, jailchannel: int):
+        overwriteHide = discord.PermissionOverwrite()
+        overwriteShow = discord.PermissionOverwrite()
+        overwriteHide.view_channel=False
+        overwriteShow.view_channel=True
+        for channel in channels:
+                if(channel.id == jailchannel):
+                    await channel.set_permissions(user, overwrite=overwriteShow)
+                else:
+                    await channel.set_permissions(user, overwrite=overwriteHide)
+
+    async def undo_softban(user: discord.user, channels: discord.Guild.channels):
+        for channel in channels:
+                await channel.set_permissions(user, overwrite=None)
+
     @app_commands.command(name="revokesoftban", description="Nimmt den Softban wieder zurück")
     @app_commands.describe(user="Der User bei dem der Softban wieder zurück genommen werden soll")
     async def revokesoftban(self, interaction: discord.Interaction, user: discord.User):
@@ -851,8 +860,7 @@ class Modsystem(commands.Cog):
                 raise Exception("Du kannst keinen User mit einem höheren oder gleichen Rang Softbannen")
             elif(await self.config.guild(interaction.guild).users.get_raw(user.id, 'softBanned') == False):
                 raise Exception("Dieser User hat aktuell keinen Softban")
-            for channel in interaction.guild.channels:
-                await channel.set_permissions(user, overwrite=None)
+            await Modsystem.undo_softban(user, interaction.guild.channels)
             await self.config.guild(interaction.guild).users.set_raw(user.id, 'softBanned', value=False)
             await user.send(f"Dein Softban auf **{interaction.guild.name}** wurde zurückgenommen")
             embedLog.description=f"Der **Softban** von {user.mention} wurde von {interaction.user.mention} aufgehoben"
@@ -1007,11 +1015,11 @@ class Modsystem(commands.Cog):
     async def init_user(self, member):
         await self.config.guild(member.guild).users.set_raw(member.id, value={'displayName': member.display_name,
                                                                                   'username': member.name,
-                                                                                  'currentReason': "",
+                                                                                  'currentReason': "-",
                                                                                   'currentPoints': 0,
                                                                                   'totalPoints': 0,
-                                                                                  'firstWarn': "",
-                                                                                  'lastWarn': "",
+                                                                                  'firstWarn': "-",
+                                                                                  'lastWarn': "-",
                                                                                   'warnCount': 0,
                                                                                   'kickCount': 0,
                                                                                   'softBanned': False,
@@ -1027,7 +1035,10 @@ class Modsystem(commands.Cog):
     @commands.Cog.listener()
     async def on_member_join(self, member):
         try:
-            await Modsystem.init_user(self, member)
+            if(await self.config.guild(member.guild).users.get_raw(member.id) is None):
+                await Modsystem.init_user(self, member)
+            if(await self.config.guild(member.guild).users.get_raw(member.id, 'softBanned')):
+                await Modsystem.do_softban(member, member.guild.channels, await self.config.guild(member.guild).softBanChannel())
             if(await self.config.guild(member.guild).enableJoinLog()):
                 if(await self.config.guild(member.guild).useGeneralLogChannel() == True):
                     channel = member.guild.get_channel(await self.config.guild(member.guild).generalLogChannel())

--- a/serverstats/__init__.py
+++ b/serverstats/__init__.py
@@ -1,0 +1,4 @@
+from .serverstats import ServerStats
+
+async def setup(bot):
+    await bot.add_cog(ServerStats(bot))

--- a/serverstats/serverstats.py
+++ b/serverstats/serverstats.py
@@ -1,0 +1,217 @@
+import discord
+
+from redbot.core import commands, app_commands, Config
+
+class ServerStats(commands.Cog):
+
+    def __init__(self, bot):
+        self.bot = bot
+        self.config = Config.get_conf(self, identifier=518963742)
+        self.config.register_guild(
+            memberCountChannel = 1199481948687585300,
+            boosterCountChannel = 0,
+            botCountChannel = 0,
+            bannedCountChannel = 0,
+            adminCountChannel = 0,
+            modCountChannel = 0,
+            helperCountChannel = 0,
+            normalUserCountChannel = 0,
+            memberChannelName = "dsaasd",
+            boosterChannelName = "asdasd",
+            botChannelName = "asddssss",
+            bannedChannelName = "sdafasagaad",
+            adminChannelName = "fdsfasf",
+            modChannelName = "sgsdfsdf",
+            helperChannelName = "sdgsdfsdf",
+            normalUserChannelName = "sdsgsdsdfsf",
+            memberActive = 0,
+            boosterActive = 0,
+            botActive = 0,
+            bannedActive = 0,
+            adminActive = 0,
+            modActive = 0,
+            helperActive = 0,
+            normalUserActive = 0
+        )
+
+    serverstats = app_commands.Group(name="serverstats", description="Manage ServerStats Channel")
+
+    @serverstats.command(name="setchannel", description="Setze Channel für Stats")
+    @app_commands.describe(counter="Welcher Counter möchtest du Konfigurieren?", channel="ChannelID des Channels der genutzt werden soll")
+    @app_commands.choices(counter=[
+            app_commands.Choice(name="Member", value="memberCountChannel"),
+            app_commands.Choice(name="Booster", value="boosterCountChannel"),
+            app_commands.Choice(name="Bot", value="botCountChannel"),
+            app_commands.Choice(name="Banned", value="bannedCountChannel"),
+            app_commands.Choice(name="Admin", value="adminCountChannel"),
+            app_commands.Choice(name="Moderator", value="modCountChannel"),
+            app_commands.Choice(name="Helper", value="helperCountChannel"),
+            app_commands.Choice(name="NormalUser", value="normalUserCountChannel")
+        ])
+    @app_commands.checks.has_permissions(administrator=True)
+    async def setchannel(self, interaction: discord.Interaction, counter: app_commands.Choice[str], channel: int):
+        try:
+            if(counter.value == "memberCountChannel"):
+                confval = self.config.guild(interaction.guild).memberCountChannel
+            elif(counter.value == "boosterCountChannel"):
+                confval = self.config.guild(interaction.guild).boosterCountChannel
+            elif(counter.value == "botCountChannel"):
+                confval = self.config.guild(interaction.guild).botCountChannel
+            elif(counter.value == "bannedCountChannel"):
+                confval = self.config.guild(interaction.guild).bannedCountChannel
+            elif(counter.value == "adminCountChannel"):
+                confval = self.config.guild(interaction.guild).modCountChannel
+            elif(counter.value == "helperCountChannel"):
+                confval = self.config.guild(interaction.guild).helperCountChannel
+            elif(counter.value == "normalUserCountChannel"):
+                confval = self.config.guild(interaction.guild).normalUserCountChannel
+            await confval.set(channel)
+            embed = discord.Embed(title="Erfolgreich", description="Es wurden folgende Werte gespeichert", color=0x0ffc03)
+            embed.add_field(name="Art", value=f"{counter.name}", inline=True)
+            embed.add_field(name="Channel", value=f"{channel}", inline=True)
+            await interaction.response.send_message(embed=embed)
+        except Exception as error:
+            embed = discord.Embed(title="Fehler", description=f"Folgender Fehler ist eingetreten: {error}", color=0xff0000)
+            await interaction.response.send_message(embed=embed)
+
+    @serverstats.command(name="setchannelname", description="Setzte den Channelnamen")
+    @app_commands.describe(counter="Counter", name="Channelname")
+    @app_commands.choices(counter=[
+        app_commands.Choice(name="Member", value="memberActive"),
+        app_commands.Choice(name="Booster", value="boosterActive"),
+        app_commands.Choice(name="Bot", value="botActive"),
+        app_commands.Choice(name="Banned", value="bannedActive"),
+        app_commands.Choice(name="Admin", value="adminActive"),
+        app_commands.Choice(name="Moderator", value="modActive"),
+        app_commands.Choice(name="Helper", value="helperActive"),
+        app_commands.Choice(name="NormalUser", value="normalUserActive")
+    ])
+    @app_commands.checks.has_permissions(administrator=True)
+    async def setchannelname(self, interaction: discord.Interaction, counter: app_commands.Choice[str], name: str):
+        try:
+            if(counter.value == "memberCountChannel"):
+                confval = self.config.guild(interaction.guild).memberChannelName
+            elif(counter.value == "boosterCountChannel"):
+                confval = self.config.guild(interaction.guild).boosterChannelName
+            elif(counter.value == "botCountChannel"):
+                confval = self.config.guild(interaction.guild).botChannelName
+            elif(counter.value == "bannedCountChannel"):
+                confval = self.config.guild(interaction.guild).bannedChannelName
+            elif(counter.value == "adminCountChannel"):
+                confval = self.config.guild(interaction.guild).modChannelName
+            elif(counter.value == "helperCountChannel"):
+                confval = self.config.guild(interaction.guild).helperChannelName
+            elif(counter.value == "normalUserCountChannel"):
+                confval = self.config.guild(interaction.guild).normalUserChannelName
+            await confval.set(name)
+            embed = discord.Embed(title="Erfolgreich", description="Es wurden folgende Werte gespeichert", color=0x0ffc03)
+            embed.add_field(name=f"{counter.name}", value=f"{name}", inline=False)
+            interaction.response.send_message(embed=embed)
+        except Exception as error:
+            embed = discord.Embed(title="Fehler", description=f"Es ist folgender Fehler aufgetreten: {error}", color=0xff0000)
+            interaction.response.send_message(embed=embed)
+
+    @serverstats.command(name="setactive", description="Aktiviere einzelne Counter")
+    @app_commands.describe(counter="Counter", active="Aktivieren?")
+    @app_commands.choices(counter=[
+        app_commands.Choice(name="Member", value="memberActive"),
+        app_commands.Choice(name="Booster", value="boosterActive"),
+        app_commands.Choice(name="Bot", value="botActive"),
+        app_commands.Choice(name="Banned", value="bannedActive"),
+        app_commands.Choice(name="Admin", value="adminActive"),
+        app_commands.Choice(name="Moderator", value="modActive"),
+        app_commands.Choice(name="Helper", value="helperActive"),
+        app_commands.Choice(name="NormalUser", value="normalUserActive")
+    ], active=[
+        app_commands.Choice(name="Ja", value=1),
+        app_commands.Choice(name="Nein", value=0)
+    ])
+    @app_commands.checks.has_permissions(administrator=True)
+    async def setactive(self, interaction: discord.Interaction, counter: app_commands.Choice[str], active: app_commands.Choice[int]):
+        try:
+            if(counter.value == "memberActive"):
+                confval = self.config.guild(interaction.guild).memberactive
+            elif(counter.value == "boosterActive"):
+                confval = self.config.guild(interaction.guild).boosterActive
+            elif(counter.value == "botActive"):
+                confval = self.config.guild(interaction.guild).botActive
+            elif(counter.value == "bannedActive"):
+                confval = self.config.guild(interaction.guild).bannedActive
+            elif(counter.value == "adminActive"):
+                confval = self.config.guild(interaction.guild).adminActive
+            elif(counter.value == "modActive"):
+                confval = self.config.guild(interaction.guild).modActive
+            elif(counter.value == "helperActive"):
+                confval = self.config.guild(interaction.guild).helperActive
+            elif(counter.value == "normalUser"):
+                confval = self.config.guild(interaction.guild).normalUser
+            await confval.set(active.value)
+            embed = discord.Embed(title="Erfolgreich", description="Es wurden folgende Werte gesetzt", color=0x0ffc03)
+            embed.add_field(name=f"{counter.name}", value=f"{active.name}", inline=False)
+            await interaction.response.send_message(embed=embed)
+        except Exception as error:
+            embed = discord.Embed(title="Fehler", description=f"Folgender Fehler ist eingetreten: {error}", color=0xff0000)
+            await interaction.response.send_message(embed=embed)
+            
+
+    @serverstats.command(name="getconf", description="Zeige die Konfiguration")
+    @app_commands.checks.has_permissions(administrator=True)
+    async def getconf(self, interaction: discord.Interaction):
+        try:
+            embed = discord.Embed(title="Aktuelle Konfiguration", description="Es wurden folgende Einstellungen konfiguriert", color=0x0ffc03)
+            art = "Member\n"
+            convertActive = lambda a : "True\n" if(a == 1) else "False\n"
+            channel = str(await self.config.guild(interaction.guild).memberCountChannel()) + "\n"
+            status = convertActive(await self.config.guild(interaction.guild).memberActive())
+            name = await self.config.guild(interaction.guild).memberChannelName() + "\n"
+            art += "Booster\n"
+            channel += str(await self.config.guild(interaction.guild).boosterCountChannel()) + "\n"
+            status += convertActive(await self.config.guild(interaction.guild).boosterActive())
+            name += await self.config.guild(interaction.guild).boosterChannelName() + "\n"
+            art += "Bot\n"
+            channel += str(await self.config.guild(interaction.guild).botCountChannel()) + "\n"
+            status += convertActive(await self.config.guild(interaction.guild).botActive())
+            name += await self.config.guild(interaction.guild).botChannelName() + "\n"
+            art  += "Banned\n"
+            channel += str(await self.config.guild(interaction.guild).bannedCountChannel()) + "\n"
+            status += convertActive(await self.config.guild(interaction.guild).bannedActive())
+            name += await self.config.guild(interaction.guild).bannedChannelName() + "\n"
+            art += "Admin\n"
+            channel += str(await self.config.guild(interaction.guild).adminCountChannel()) + "\n"
+            status += convertActive(await self.config.guild(interaction.guild).adminActive())
+            name += await self.config.guild(interaction.guild).adminChannelName() + "\n"
+            art += "Mod\n"
+            channel += str(await self.config.guild(interaction.guild).modCountChannel()) + "\n"
+            status += convertActive(await self.config.guild(interaction.guild).modActive())
+            name += await self.config.guild(interaction.guild).modChannelName() + "\n"
+            art += "Helper\n"
+            channel += str(await self.config.guild(interaction.guild).helperCountChannel()) + "\n"
+            status += convertActive(await self.config.guild(interaction.guild).helperActive())
+            name += await self.config.guild(interaction.guild).helperChannelName() + "\n"
+            art += "Normal User\n"
+            channel += str(await self.config.guild(interaction.guild).normalUserCountChannel()) + "\n"
+            status += convertActive(await self.config.guild(interaction.guild).normalUserActive())
+            name += await self.config.guild(interaction.guild).normalUserChannelName() + "\n"
+            embed.add_field(name="Art", value=f"{status}", inline=True)
+            embed.add_field(name="Channel", value=f"{channel}", inline=True)
+            embed.add_field(name="Status", value=f"{status}", inline=True)
+            embed.add_field(name="Art", value=f"{art}", inline=True)
+            embed.add_field(name="Channel Name", value=f"{name}", inline=True)
+            await interaction.response.send_message(embed=embed)
+        except Exception as error:
+            embed = discord.Embed(title="Fehler", description=f"Es ist folgendes Problem aufgetreten: {error}", color=0xff0000)
+            await interaction.response.send_message(embed=embed)
+
+    @commands.command()
+    async def setChannel(self, interaction: discord.Interaction, channelID: int, name: str):
+        try:
+            intents = discord.Intents()
+            intents.presences
+            intents.members = True
+            print(channelID)
+            valueset = await self.config.guild(interaction.guild).get_raw(channelID)
+            print(valueset)
+            #channel = discord.utils.get(self.guild.channels, id=1199481948687585300)
+            #await channel.edit(name=f"Erfolgreich!")
+        except Exception as error:
+            print(f"Error: {error}")


### PR DESCRIPTION
When a user get a softban he could simply rejoin to evade the softban, this is now fixed aswell as some minor changes to showconfig layout